### PR TITLE
Add a -amd64 or  -arm64 suffix to the version tag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=nanoandrew4/ngcplogs
-PLUGIN_TAG=v1.2.0
+ARCH=`./arch.sh`
+PLUGIN_TAG=v1.2.0-${ARCH}
 PLUGIN_DIR=./ngcplogs-plugin
 all: clean docker rootfs create
 local: clean docker rootfs create enable

--- a/arch.sh
+++ b/arch.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+case `uname -m` in
+x86_64)
+	echo "amd64"
+	;;
+aarch64)
+	echo "arm64"
+	;;
+*)
+	echo "unknow"
+	;;
+esac


### PR DESCRIPTION
This change enables to use multiple architectures for the plugin. The managed plugin archticture of Docker does not have any provisions to support something like docker buildx for plugins, so emulate that a bit by using different version tags.