### PR TITLE
Also handle the case if an app uses numeric severity codes already.

### DIFF
--- a/ngcplogger.go
+++ b/ngcplogger.go
@@ -304,6 +304,13 @@ func (l *nGCPLogger) extractSeverityFromPayload(m map[string]any) logging.Severi
 					}
 					break
 				}
+				if parsedSeverity, isNumber := rawSeverity.(float64); isNumber {
+					severity = logging.Severity(parsedSeverity)
+					if severity != logging.Default { // severity was parsed correctly, we can remove it from the jsonPayload section
+						delete(m, severityField)
+					}
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If you have an app that already logs a numeric severity level, it can be used directly for the GCP severity field. 