### PR TITLE
Docker speedup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /goapp
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go mod download
 COPY *.go ./
-ARG TARGETOS TARGETARCH
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o ngcplogs .
 
 FROM alpine:3.19.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM golang:1.22.1-alpine as build
+FROM --platform=$BUILDPLATFORM golang:1.22.1-alpine as build
 
-COPY *.go /go/src/github.com/nanoandrew4/ngcplogs/
-COPY go.mod /go/src/github.com/nanoandrew4/ngcplogs/
-COPY go.sum /go/src/github.com/nanoandrew4/ngcplogs/
-
-RUN cd /go/src/github.com/nanoandrew4/ngcplogs && go get && go build --ldflags '-extldflags "-static"' -o /usr/bin/ngcplogs
+WORKDIR /goapp
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go mod download
+COPY *.go ./
+ARG TARGETOS TARGETARCH
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o ngcplogs .
 
 FROM alpine:3.19.1
-COPY --from=build /usr/bin/ngcplogs usr/bin
+COPY --from=build /goapp/ngcplogs usr/bin
 
 WORKDIR /usr/bin
 ENTRYPOINT [ "/usr/bin/ngcplogs" ]

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/docker/go-plugins-helpers v0.0.0-20211224144127-6eecb7beb651
 	github.com/gogo/protobuf v1.3.2
 	github.com/pkg/errors v0.9.1
+	google.golang.org/api v0.155.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240311173647-c811ad7063a7
 )
 
@@ -58,8 +59,8 @@ require (
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	google.golang.org/api v0.155.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
+	google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240311132316-a219d84964c2 // indirect
 	google.golang.org/grpc v1.62.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect


### PR DESCRIPTION
I am trying out various variations of getting the gcp log info extracted, and building everything with qemu is very slow. This change for the docker build employs caching and cross compiling using the host cpu to make this process much faster.