### PR TITLE
Add missing spanID extraction for caddy.

### DIFF
--- a/ngcplogger.go
+++ b/ngcplogger.go
@@ -486,6 +486,11 @@ func (l *nGCPLogger) extractCaddyFromPayload(m map[string]any, entry *logging.En
 			entry.Trace = "projects/" + l.projectID + "/traces/" + val.(string)
 			delete(m, "traceID")
 		}
+		if val, exists := m["spanID"]; exists {
+			entry.SpanID = val.(string)
+			entry.TraceSampled = true
+			delete(m, "spanID")
+		}
 	}
 }
 


### PR DESCRIPTION
If using OTEL the spanID must be populated in the logs as well, other wise the waterfall view in the logs explorer will not appear.